### PR TITLE
[44기 장다희] FIX: product detail Dao subquery row 1개 이상 나오는 에러 수정

### DIFF
--- a/API/models/productDao.js
+++ b/API/models/productDao.js
@@ -17,15 +17,18 @@ const productDetail = async (productId) => {
             FROM buyings b
             JOIN deals d
             ON d.buying_id = b.id
-            WHERE d.created_at = (SELECT max(created_at) FROM deals)) recentDealPrice,
+            WHERE d.created_at = (SELECT max(created_at) FROM deals)
+            LIMIT 1) recentDealPrice,
             (SELECT 
                 bid_price
             FROM sellings
-            WHERE bid_price = (SELECT min(bid_price) FROM sellings WHERE bid_status_id = 1)) buyNowPrice,
+            WHERE bid_price = (SELECT min(bid_price) FROM sellings WHERE bid_status_id = 1)
+            LIMIT 1) buyNowPrice,
             (SELECT 
                 bid_price
             FROM buyings
-            WHERE bid_price = (SELECT max(bid_price) FROM buyings WHERE bid_status_id = 1)) sellNowPrice,
+            WHERE bid_price = (SELECT max(bid_price) FROM buyings WHERE bid_status_id = 1)
+            LIMIT 1) sellNowPrice,
             (SELECT 
               COUNT(user_id)
             FROM likes


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- product detail 데이터 중 최근 거래가, 즉시 구매/판매가 도출하는 sub-query가 최대/최소값이 동일한 값이 2개 이상있을 때 에러가 나는 문제 해결

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- sub-query에 `LIMIT 1` 추가

<br />

## :: 테스트 결과 이미지
![image](https://user-images.githubusercontent.com/120387100/234516383-4d1417ce-76d6-4f2a-863a-14321a218088.png)


<br />

## :: 기타 질문 및 특이 사항
