### PR TITLE
[44기 장다희] FIX: proudct detail 정보 제공 API 에러 수정 & bidDao class화

### DIFF
--- a/API/models/bidDao.js
+++ b/API/models/bidDao.js
@@ -1,0 +1,75 @@
+const appDataSource = require('./appDataSource');
+const { bidStatusEnum } = require('./enum');
+const { DatabaseError } = require('../utils/error');
+
+class BidCase {
+  constructor(productId, bidType, bidPrice) {
+    this.bidType = bidType;
+    this.bidPrice = bidPrice;
+    this.productId = productId;
+    this.counterpart = bidType == 'buying' ? 'selling' : 'buying';
+    this.commissionRate = bidType == 'buying' ? 0.02 : 0.05;
+    this.table = `${bidType}s`;
+    this.counterTable = `${this.counterpart}s`;
+    this.minOrMax = this.counterpart == 'selling' ? 'min' : 'max';
+    this.appDataSource = appDataSource;
+  }
+
+  async nowPriceSetter(productIdValue, table, minOrMax) {
+    try {
+      const [bidPrice] = await this.appDataSource.query(
+        ` 
+        SELECT 
+            bid_price bidPrice
+        FROM ${table}
+        WHERE bid_price = (SELECT ${minOrMax}(bid_price) FROM ${table} WHERE bid_status_id = ${bidStatusEnum.bid} AND product_id = ${productIdValue}) 
+        `
+      );
+      return parseFloat(Object.values(bidPrice));
+    } catch (err) {
+      err.message = 'DATABASE_ERROR';
+      err.statusCode = 400;
+      throw err;
+    }
+  }
+
+  getBuyNowPrice() {
+    return this.nowPriceSetter(this.productId, 'sellings', 'min');
+  }
+
+  getSellNowPrice() {
+    return this.nowPriceSetter(this.productId, 'buyings', 'max');
+  }
+
+  getNowPrice() {
+    return this.nowPriceSetter(
+      this.productId,
+      this.counterTable,
+      this.minOrMax
+    );
+  }
+
+  async getRecentDealPrice() {
+    try {
+      const [bidPrice] = await this.appDataSource.query(
+        ` 
+            SELECT 
+                b.bid_price bidPrice
+            FROM deals d
+            JOIN buyings b ON b.id = d.buying_id
+            WHERE d.created_at = (SELECT max(created_at) FROM deals) AND b.product_id = ${this.productId}
+            ORDER BY d.created_at DESC
+            `
+      );
+      return parseFloat(Object.values(bidPrice));
+    } catch (err) {
+      err.message = 'DATABASE_ERROR';
+      err.statusCode = 400;
+      throw err;
+    }
+  }
+}
+
+module.exports = {
+  BidCase,
+};

--- a/API/models/enum.js
+++ b/API/models/enum.js
@@ -1,0 +1,9 @@
+const bidStatusEnum = Object.freeze({
+  bid: 1,
+  deal: 2,
+  fail: 3,
+});
+
+module.exports = {
+  bidStatusEnum,
+};

--- a/API/models/productDao.js
+++ b/API/models/productDao.js
@@ -12,37 +12,19 @@ const productDetail = async (productId) => {
             pi.url imageUrl,
             pa.age productAge,
             pl.level productLevel,
-            (SELECT 
-                b.bid_price
-            FROM buyings b
-            JOIN deals d
-            ON d.buying_id = b.id
-            WHERE d.created_at = (SELECT max(created_at) FROM deals)
-            LIMIT 1) recentDealPrice,
-            (SELECT 
-                bid_price
-            FROM sellings
-            WHERE bid_price = (SELECT min(bid_price) FROM sellings WHERE bid_status_id = 1)
-            LIMIT 1) buyNowPrice,
-            (SELECT 
-                bid_price
-            FROM buyings
-            WHERE bid_price = (SELECT max(bid_price) FROM buyings WHERE bid_status_id = 1)
-            LIMIT 1) sellNowPrice,
-            (SELECT 
-              COUNT(user_id)
-            FROM likes
-            GROUP BY product_id) likeCount
+            l.likeCount
         FROM products p
         JOIN categories c ON p.category_id = c.id
         JOIN product_images pi ON p.id = pi.product_id
         JOIN product_ages pa ON p.product_age_id = pa.id
         JOIN product_levels pl ON p.product_level_id = pl.id
-        LEFT JOIN buyings b ON b.product_id = p.id
-        LEFT JOIN sellings s ON s.product_id = p.id
-        LEFT JOIN likes l ON l.product_id = p.id
+        LEFT JOIN (SELECT 
+            product_id,
+            COUNT(id) likeCount
+         FROM likes
+         GROUP BY product_id) l ON l.product_id = p.id
         WHERE p.id = ?
-    `,
+              `,
       [productId]
     );
     return productDetail;

--- a/API/services/productService.js
+++ b/API/services/productService.js
@@ -1,5 +1,6 @@
 const productDao = require('../models/productDao');
 const { BaseError } = require('../utils/error');
+const { BidCase } = require('../models/bidDao');
 
 const getProductDetail = async (productId) => {
   const checkProductId = await productDao.isExistingProduct(productId);
@@ -9,11 +10,17 @@ const getProductDetail = async (productId) => {
   }
 
   const productDetail = await productDao.productDetail(productId);
+  const bidCase = new BidCase(productId);
+
+  productDetail.buyNowPrice = await bidCase.getBuyNowPrice();
+  productDetail.sellNowPrice = await bidCase.getSellNowPrice();
+  productDetail.recentDealPrice = await bidCase.getRecentDealPrice();
   productDetail.premiumPercent = (
     ((productDetail.recentDealPrice - productDetail.originalPrice) /
       productDetail.originalPrice) *
     100
   ).toFixed(1);
+
   return productDetail;
 };
 

--- a/API/utils/error.js
+++ b/API/utils/error.js
@@ -5,6 +5,7 @@ const catchAsync = (func) => {
 };
 
 const globalErrorHandler = (err, req, res, next) => {
+  console.error(err);
   err.statusCode = err.statusCode || 500;
   res.status(err.statusCode).json({ message: err.message });
 };

--- a/tests/tests/products.test.js
+++ b/tests/tests/products.test.js
@@ -142,10 +142,10 @@ describe('prdouct detail', () => {
       'imageUrl',
       'productAge',
       'productLevel',
-      'recentDealPrice',
+      'likeCount',
       'buyNowPrice',
       'sellNowPrice',
-      'likeCount',
+      'recentDealPrice',
       'premiumPercent',
     ]);
     expect(response.statusCode).toEqual(200);


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 데이터베이스 작업
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- product detail 정보 요청 처리 시 발생하는 query문 에러 수정
- 추후 입찰 API에 사용될 쿼리문의 모듈화와 함수 확장성 제고를 위한 Dao의 class화 
- (추가 수정) appDataSource 직접 호출하지 않고, 파일 상단에서 호출 후 constructor에 변수로 할당
- (추가 수정) 본 API와 무관한 코드 삭제

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 에러 확률 줄이고 확장성 높이기 위해 '즉시 구매/판매가'와 '최근 거래가' 도출 함수를 product Detail 정보 도출 쿼리문 함수와 분리함.
- 추후 입찰 API의 '판매 입찰', '구매 입찰' 요청에 따라 효율적으로 대응하기 위해 입찰 관련 bidDao를 Class로 작성


<br />

## :: 테스트 결과 이미지
![image](https://user-images.githubusercontent.com/120387100/234930392-192feb60-536d-4a2c-9b02-d77114e84122.png)


<br />

## :: 기타 질문 및 특이 사항