### PR TITLE
[44기 장다희] ADD: 입찰 기능 구현

### DIFF
--- a/API/controllers/bidController.js
+++ b/API/controllers/bidController.js
@@ -18,7 +18,36 @@ const infoByproductId = catchAsync(async (req, res) => {
 
   return res.status(200).json(data);
 });
+
+const inputBidPrice = catchAsync(async (req, res) => {
+  const { productId, bidType, bidPrice, dueDate } = req.body;
+
+  if (
+    !productId ||
+    !bidType ||
+    !bidPrice ||
+    !dueDate ||
+    !(bidType == 'buying' || bidType == 'selling')
+  ) {
+    const error = new Error('KEY ERROR');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const userId = req.user.id;
+  const inputResult = await bidService.inputBidPrice(
+    productId,
+    bidType,
+    bidPrice,
+    dueDate,
+    userId
+  );
+
+  res.status(201).json(inputResult);
+});
+
 module.exports = {
   graphByTerm,
   infoByproductId,
+  inputBidPrice,
 };

--- a/API/models/bidDao.js
+++ b/API/models/bidDao.js
@@ -1,18 +1,22 @@
 const appDataSource = require('./appDataSource');
+
 const { bidStatusEnum } = require('./enum');
 const { DatabaseError } = require('../utils/error');
 const graphQueryBuilder = require('./bidQueryBuilder');
 
 class BidCase {
-  constructor(productId, bidType, bidPrice) {
+  constructor(productId, bidType, bidPrice, dueDate, userId) {
     this.bidType = bidType;
     this.bidPrice = bidPrice;
     this.productId = productId;
     this.counterpart = bidType == 'buying' ? 'selling' : 'buying';
     this.commissionRate = bidType == 'buying' ? 0.02 : 0.05;
+    this.counterCommissionRate = bidType == 'buying' ? 0.05 : 0.02;
     this.table = `${bidType}s`;
     this.counterTable = `${this.counterpart}s`;
     this.minOrMax = this.counterpart == 'selling' ? 'min' : 'max';
+    this.dueDate = dueDate;
+    this.userId = userId;
     this.appDataSource = appDataSource;
   }
 
@@ -47,7 +51,7 @@ class BidCase {
     return this.nowPriceSetter(this.productId, 'buyings', 'max');
   }
 
-  getNowPrice() {
+  async getNowPrice() {
     return this.nowPriceSetter(
       this.productId,
       this.counterTable,
@@ -63,7 +67,9 @@ class BidCase {
                 b.bid_price AS bidPrice
             FROM deals d
             JOIN buyings b ON b.id = d.buying_id
-            WHERE d.created_at = (SELECT max(created_at) FROM deals) AND b.product_id = ${this.productId}
+            WHERE d.created_at = 
+            (SELECT max(d.created_at) FROM deals JOIN buyings b ON b.id = d.buying_id WHERE b.product_id = ${this.productId}) 
+            AND b.product_id = ${this.productId}
             ORDER BY d.created_at DESC
             `
       );
@@ -78,6 +84,145 @@ class BidCase {
       err.message = 'DATABASE_ERROR';
       err.statusCode = 400;
       throw err;
+    }
+  }
+
+  async isNowPrice() {
+    const nowPrice = await this.getNowPrice();
+    if (
+      nowPrice &&
+      ((this.bidType == 'buying' && this.bidPrice - nowPrice >= 0) ||
+        (this.bidType == 'selling' && this.bidPrice - nowPrice <= 0))
+    ) {
+      this.bidPrice = nowPrice;
+      return this.bidPrice;
+    }
+    return false;
+  }
+
+  async isExistingBid() {
+    try {
+      const [result] = await appDataSource.query(
+        `SELECT EXISTS (
+            SELECT
+            id
+            FROM ${this.table}
+            WHERE user_id = ${this.userId} AND product_id = ${this.productId} AND bid_status_id = ${bidStatusEnum.bid}
+            ) existing 
+            `
+      );
+      return !!parseInt(result.existing);
+    } catch (err) {
+      err.message = 'DATABASE_ERROR';
+      err.statusCode = 400;
+      throw err;
+    }
+  }
+
+  async biddingIn() {
+    const queryRunner = this.appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      await this.isNowPrice();
+      if (await this.isExistingBid()) {
+        await queryRunner.query(
+          `UPDATE ${this.table}
+        SET bid_price = ${this.bidPrice}
+        WHERE user_id = ${this.userId} AND product_id = ${this.productId} AND bid_status_id = ${bidStatusEnum.bid}`
+        );
+
+        const [bidding] = await queryRunner.query(
+          `SELECT
+            id
+        FROM ${this.table}
+        WHERE user_id = ${this.userId} AND product_id = ${this.productId} AND bid_status_id = ${bidStatusEnum.bid}
+        `
+        );
+        this.biddingId = bidding.id;
+      } else {
+        const bidding = await queryRunner.query(
+          ` INSERT INTO ${this.table} (
+                product_id,
+                bid_price,
+                due_date,
+                user_id
+                )
+                VALUES (?, ?, ?, ?)`,
+          [this.productId, this.bidPrice, this.dueDate, this.userId]
+        );
+
+        this.biddingId = bidding.insertId;
+      }
+
+      if (!(await this.isNowPrice())) {
+        await queryRunner.commitTransaction();
+        return;
+      }
+
+      const [partner] = await queryRunner.query(
+        `SELECT
+        id,
+        user_id userId 
+        FROM ${this.counterTable}
+        WHERE updated_at = 
+        (SELECT 
+            min(updated_at)
+        FROM ${this.counterTable}
+        WHERE product_id = ${this.productId} AND bid_price = ${this.bidPrice} AND bid_status_id = ${bidStatusEnum.bid})
+        AND product_id = ${this.productId} AND bid_price = ${this.bidPrice} AND bid_status_id = ${bidStatusEnum.bid}
+        ORDER BY updated_at`
+      );
+
+      if (partner.userId == this.userId) {
+        const err = new Error('SAME_USER_WITH_COUNTERPART');
+        err.statusCode = 400;
+        throw err;
+      }
+
+      await queryRunner.query(
+        `UPDATE ${this.table} t
+        JOIN ${this.counterTable} c
+        SET t.bid_status_id = ${bidStatusEnum.deal},
+            c.bid_status_id = ${bidStatusEnum.deal}
+        WHERE t.id = ${this.biddingId} AND c.id = ${partner.id}`
+      );
+
+      const dealInput = await queryRunner.query(
+        ` INSERT INTO deals (
+            ${this.bidType + '_id'},
+            ${this.counterpart + '_id'},
+            ${this.bidType + '_commission'},
+            ${this.counterpart + '_commission'}
+            )
+            VALUES (?, ?, ?, ?)`,
+        [
+          this.biddingId,
+          partner.id,
+          this.commissionRate * this.bidPrice,
+          this.counterCommissionRate * this.bidPrice,
+        ]
+      );
+
+      [this.dealInfo] = await queryRunner.query(
+        `
+        SELECT
+            id,
+            deal_number dealNumber
+        FROM deals
+        WHERE id = ?`,
+        [dealInput.insertId]
+      );
+
+      await queryRunner.commitTransaction();
+      return;
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      err.message = err.message || 'DATABASE_ERROR';
+      err.statusCode = 400;
+      throw err;
+    } finally {
+      await queryRunner.release();
     }
   }
 }

--- a/API/routes/bidRouter.js
+++ b/API/routes/bidRouter.js
@@ -1,10 +1,14 @@
 const express = require('express');
+const checkLogInToken = require('../utils/auth');
 const bidController = require('../controllers/bidController');
 
 const router = express.Router();
 
 router.get('/graph/:productId', bidController.graphByTerm);
 router.get('/info/:productId', bidController.infoByproductId);
+
+router.post('/input', checkLogInToken, bidController.inputBidPrice);
+
 module.exports = {
   router,
 };

--- a/API/routes/index.js
+++ b/API/routes/index.js
@@ -1,8 +1,7 @@
 const express = require('express');
 const productRouter = require('./productRouter');
-const userRouter = require('./userRouter');
-
 const bidRouter = require('./bidRouter');
+const userRouter = require('./userRouter');
 
 const router = express.Router();
 

--- a/API/services/bidService.js
+++ b/API/services/bidService.js
@@ -1,5 +1,7 @@
 const bidDao = require('../models/bidDao');
+const productDao = require('../models/productDao');
 const { BaseError } = require('../utils/error');
+const { BidCase } = require('../models/bidDao');
 
 const graphByTerm = async (productId, term) => {
   let graphData = await bidDao.graphByTerm(productId, term);
@@ -28,7 +30,30 @@ const infoByproductId = async (productId) => {
   const deal = await bidDao.dealInfo(productId);
   return { selling: sellings, buying: buyings, deal: deal };
 };
+
+const inputBidPrice = async (productId, bidType, bidPrice, dueDate, userId) => {
+  const bidCase = new BidCase(productId, bidType, bidPrice, dueDate, userId);
+  await bidCase.biddingIn();
+
+  const { productName, modelNumber, imageUrl } = await productDao.productDetail(
+    productId
+  );
+  const inputResult = {
+    dealId: (bidCase.dealInfo && bidCase.dealInfo.id) || null,
+    dealNumber: (bidCase.dealInfo && bidCase.dealInfo.dealNumber) || null,
+    commission: bidCase.commissionRate * bidCase.bidPrice,
+    productName: productName,
+    modelNumber: modelNumber,
+    imageUrl: imageUrl,
+    dueDate: dueDate,
+    bidPrice: bidCase.bidPrice,
+  };
+
+  return inputResult;
+};
+
 module.exports = {
   graphByTerm,
   infoByproductId,
+  inputBidPrice,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 상세 페이지에서 구매 혹은 판매 입찰을 클릭하였을 때 입찰 금액이 데이터 베이스에 저장되는 기능 구현
> - 이미 동일한 user가 입찰한 상품일 경우 입찰 금액이 update됨
> - 즉시 거래 (구매/판매)가 가능한 금액을 입력한 경우 바로 거래가 성사(deal) 되어 deal Id와  dealNumber(일반적인 order Number와 같은 개념)를 반환함
> - 같은 user가 한 거래(deal)에 대해 판매와 구매를 동시에 맡을 수 없도록 예외 처리함

- product Detail 'recent Deal Price' 관련 에러 수정 

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- POST 메서드로 바디에 필요한 property를 전달받아 입찰 금액 저장/업데이트 기능을 실행한 뒤, response로 client가 다음 페이지에서 필요한 info를 전달하는 API 구현
- bidDao에서 class 메서드로 기능 구현


<br />

## :: 테스트 결과 이미지
1. deal 성사 안된 경우
![image](https://user-images.githubusercontent.com/120387100/235337424-8e5c9827-78ff-40f1-9e23-5aaadf1c6621.png)


2. deal 성사된 경우
![image](https://user-images.githubusercontent.com/120387100/235337447-fbc20836-be46-4b51-9127-a21452dcf303.png)


3. 같은 유저가 거래 상대편이 될 수 없음
![image](https://user-images.githubusercontent.com/120387100/235337439-d7ddbf6b-e487-4131-b367-ea64b70f3f77.png)


4. KEY Error
![image](https://user-images.githubusercontent.com/120387100/235337458-802b685a-585e-490e-9ff8-0af3bf42cc88.png)


<br />

## :: 기타 질문 및 특이 사항
- bidDao에서 await로 bidding in 프로세스가 동기적으로 처리되게 하여, 예외 처리를 진행하였는데, 이보다 더 효율적인 처리 방식이 있을까요?
