### PR TITLE
[44기 장다희] ADD: account number & card number 저장/조회 기능

### DIFF
--- a/API/controllers/userController.js
+++ b/API/controllers/userController.js
@@ -40,4 +40,46 @@ const addressByUserId = catchAsync(async (req, res) => {
   const addresses = await userService.addressByUserId(userId);
   return res.status(200).json(addresses);
 });
-module.exports = { signInKakao, getUserById, addressByUserId, inputAddress };
+
+const inputNewAccount = catchAsync(async (req, res) => {
+  const { accountNumber } = req.body;
+
+  if (!accountNumber) throw new BaseError('KEY_ERROR', 400);
+
+  const userId = req.user.id;
+  const newAccountId = await userService.inputNewCard(accountNumber, userId);
+  return res.status(201).json({ accountId: newAccountId });
+});
+
+const inputNewCard = catchAsync(async (req, res) => {
+  const { cardNumber } = req.body;
+
+  if (!cardNumber) throw new BaseError('KEY_ERROR', 400);
+
+  const userId = req.user.id;
+  const newCardId = await userService.inputNewCard(cardNumber, userId);
+  return res.status(201).json({ cardId: newCardId });
+});
+
+const getAccountListByUser = catchAsync(async (req, res) => {
+  const userId = req.user.id;
+  const accountList = await userService.getAccountListByUser(userId);
+  return res.status(200).json(accountList);
+});
+
+const getCardListByUser = catchAsync(async (req, res) => {
+  const userId = req.user.id;
+  const cardList = await userService.getCardListByUser(userId);
+  return res.status(200).json(cardList);
+});
+
+module.exports = {
+  signInKakao,
+  getUserById,
+  inputNewAccount,
+  inputNewCard,
+  getAccountListByUser,
+  getCardListByUser,
+  addressByUserId,
+  inputAddress,
+};

--- a/API/models/userDao.js
+++ b/API/models/userDao.js
@@ -95,10 +95,90 @@ const addressByUserId = async (userId) => {
   );
 };
 
+const inputNewAccount = async (accountNumber, userId) => {
+  try {
+    const insertInfo = await appDataSource.query(
+      `
+    INSERT INTO account_numbers (
+      user_id,
+      account_number
+    )
+    VALUES (?, ?)
+    `,
+      [userId, accountNumber]
+    );
+    return insertInfo.insertId;
+  } catch {
+    throw new DatabaseError('DataSource_Error', 400);
+  }
+};
+
+const inputNewCard = async (cardNumber, userId) => {
+  try {
+    const insertInfo = await appDataSource.query(
+      `
+      INSERT INTO card_numbers (
+        user_id,
+        card_number
+      )
+      VALUES (?, ?)
+    `,
+      [userId, cardNumber]
+    );
+    return insertInfo.insertId;
+  } catch {
+    throw new DatabaseError('DataSource_Error', 400);
+  }
+};
+
+const getAccountListByUser = async (userId) => {
+  try {
+    const accountList = await appDataSource.query(
+      `
+      SELECT
+        id accountId,
+        account_number accountNumber
+      FROM account_numbers
+      WHERE user_id = ?
+      ORDER BY id DESC
+      `,
+      [userId]
+    );
+
+    return accountList;
+  } catch {
+    throw new DatabaseError('DataSource_Error', 400);
+  }
+};
+
+const getCardListByUser = async (userId) => {
+  try {
+    const cardList = await appDataSource.query(
+      `
+      SELECT
+        id cardId,
+        card_number cardNumber
+      FROM card_numbers
+      WHERE user_id = ?
+      ORDER BY id DESC
+      `,
+      [userId]
+    );
+
+    return cardList;
+  } catch {
+    throw new DatabaseError('DataSource_Error', 400);
+  }
+};
+
 module.exports = {
   getUserByKakaoId,
   getUserById,
   createUser,
   inputAddress,
   addressByUserId,
+  inputNewAccount,
+  inputNewCard,
+  getAccountListByUser,
+  getCardListByUser,
 };

--- a/API/routes/userRouter.js
+++ b/API/routes/userRouter.js
@@ -9,4 +9,9 @@ router.post('/kakaologin', userController.signInKakao);
 router.get('/userInfo', checkLogInToken, userController.getUserById);
 router.post('/address', checkLogInToken, userController.inputAddress);
 router.get('/address', checkLogInToken, userController.addressByUserId);
+router.post('/account', checkLogInToken, userController.inputNewAccount);
+router.post('/card', checkLogInToken, userController.inputNewCard);
+router.get('/account', checkLogInToken, userController.getAccountListByUser);
+router.get('/card', checkLogInToken, userController.getCardListByUser);
+
 module.exports = { router };

--- a/API/services/userService.js
+++ b/API/services/userService.js
@@ -49,4 +49,27 @@ const inputAddress = async (userId, address, detail_address, receiver) => {
   );
   return addressId;
 };
-module.exports = { signInKakao, getUserById, inputAddress, addressByUserId };
+
+const inputNewAccount = async (accountNumber, userId) => {
+  return userDao.inputNewAccount(accountNumber, userId);
+};
+const inputNewCard = async (cardNumber, userId) => {
+  return userDao.inputNewCard(cardNumber, userId);
+};
+const getAccountListByUser = async (userId) => {
+  return userDao.getAccountListByUser(userId);
+};
+const getCardListByUser = async (userId) => {
+  return userDao.getCardListByUser(userId);
+};
+
+module.exports = {
+  signInKakao,
+  getUserById,
+  inputNewAccount,
+  inputNewCard,
+  getAccountListByUser,
+  getCardListByUser,
+  inputAddress,
+  addressByUserId,
+};


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 판매-정산 페이지에서 (입찰/즉시 판매 모두 해당) 계좌번호와 카드 번호 입력 및 조회하는 API 구현
- 1. 새로운 계좌/카드 번호 등록 API
- 2. user별 계좌/카드번호 조회 API

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 계좌번호, 카드 번호 각각 GET,POST 메서드를 사용하여, 총 4개의 API 작성


<br />

## :: 테스트 결과 이미지
![image](https://user-images.githubusercontent.com/120387100/235614866-d7549b08-5ed6-4d5c-8922-43882467abdb.png)

![image](https://user-images.githubusercontent.com/120387100/235614908-a8693814-fbed-4066-8229-27cbc7fc1134.png)

![image](https://user-images.githubusercontent.com/120387100/235614963-62dfa86a-429d-4514-a911-0584baacd971.png)

![image](https://user-images.githubusercontent.com/120387100/235615217-9fec2848-3ff6-4373-beca-a55afba5bc64.png)


<br />

## :: 기타 질문 및 특이 사항
